### PR TITLE
Add skeletons of basic weak preservation laws

### DIFF
--- a/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
@@ -39,4 +39,13 @@ interpretation basic: weak_transition_system basic_silent basic.absorb basic_tra
 notation basic.weak.pre_bisimilarity (infix "\<lessapprox>\<^sub>\<flat>" 50)
 notation basic.weak.bisimilarity (infix "\<approx>\<^sub>\<flat>" 50)
 
+lemma basic_weak_receive_preservation: "(\<And>x. P x \<approx>\<^sub>\<flat> Q x) \<Longrightarrow> a \<triangleright> x. P x \<approx>\<^sub>\<flat> a \<triangleright> x. Q x"
+  sorry
+
+lemma basic_weak_parallel_preservation: "p \<approx>\<^sub>\<flat> q \<Longrightarrow> p \<parallel> r \<approx>\<^sub>\<flat> q \<parallel> r"
+  sorry
+
+lemma basic_weak_new_channel_preservation: "(\<And>a. P a \<approx>\<^sub>\<flat> Q a) \<Longrightarrow> \<nu> a. P a \<approx>\<^sub>\<flat> \<nu> a. Q a"
+  sorry
+
 end


### PR DESCRIPTION
This adds the preservation laws of the basic weak transition system with fake proofs (`sorry`). These skeletons will become obsolete once the generic versions of the core bisimilarity proofs of the basic transition system are in place.