### PR TITLE
Add skeletons for `(∼)`–`(≈)` implications

### DIFF
--- a/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
@@ -39,6 +39,13 @@ interpretation basic: weak_transition_system basic_silent basic.absorb basic_tra
 notation basic.weak.pre_bisimilarity (infix "\<lessapprox>\<^sub>\<flat>" 50)
 notation basic.weak.bisimilarity (infix "\<approx>\<^sub>\<flat>" 50)
 
+(* NOTE:
+  This will become obsolete once there is only one locale interpretation for the strong transition
+  system.
+*)
+lemma basic_strong_bisimilarity_in_weak_bisimilarity: "(\<sim>\<^sub>\<flat>) \<le> (\<approx>\<^sub>\<flat>)"
+  sorry
+
 lemma basic_weak_receive_preservation: "(\<And>x. P x \<approx>\<^sub>\<flat> Q x) \<Longrightarrow> a \<triangleright> x. P x \<approx>\<^sub>\<flat> a \<triangleright> x. Q x"
   sorry
 

--- a/Isabelle/Chi_Calculus/Proper_Weak_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Proper_Weak_Transition_System.thy
@@ -36,6 +36,13 @@ interpretation proper: weak_transition_system proper_silent proper.absorb proper
 notation proper.weak.pre_bisimilarity (infix "\<lessapprox>\<^sub>\<sharp>" 50)
 notation proper.weak.bisimilarity (infix "\<approx>\<^sub>\<sharp>" 50)
 
+(* NOTE:
+  This will become obsolete once there is only one locale interpretation for the strong transition
+  system.
+*)
+lemma basic_strong_bisimilarity_in_weak_bisimilarity: "(\<sim>\<^sub>\<sharp>) \<le> (\<approx>\<^sub>\<sharp>)"
+  sorry
+
 lemma basic_weak_bisimilarity_in_proper_weak_bisimilarity: "(\<approx>\<^sub>\<flat>) \<le> (\<approx>\<^sub>\<sharp>)"
   sorry
 


### PR DESCRIPTION
This adds skeletons for specific versions of `strong_bisimulation_is_weak_bisimulation`. Currently these are needed because for every concrete transition system (`basic` and `proper`) we have two strong transition system interpretations: one that’s created directly and one that’s created under the name `strong` as part of `weak_transition_system`. Once this issue is fixed, those skeletons will become obsolete.