### PR TITLE
Introduce variants of parallel unit laws

### DIFF
--- a/Isabelle/Chi_Calculus/Basic_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Basic_Transition_System.thy
@@ -904,42 +904,42 @@ end
 context begin
 
 private inductive
-  parallel_unit_aux :: "process \<Rightarrow> process \<Rightarrow> bool"
+  parallel_unit_left_aux :: "process \<Rightarrow> process \<Rightarrow> bool"
 where
   without_new_channel_ltr: "
-    parallel_unit_aux (\<zero> \<parallel> p) p" |
+    parallel_unit_left_aux (\<zero> \<parallel> p) p" |
   without_new_channel_rtl: "
-    parallel_unit_aux p (\<zero> \<parallel> p)" |
+    parallel_unit_left_aux p (\<zero> \<parallel> p)" |
   with_new_channel: "
-    (\<And>a. parallel_unit_aux (S a) (T a)) \<Longrightarrow>
-    parallel_unit_aux (\<nu> a. S a) (\<nu> a. T a)"
+    (\<And>a. parallel_unit_left_aux (S a) (T a)) \<Longrightarrow>
+    parallel_unit_left_aux (\<nu> a. S a) (\<nu> a. T a)"
 
-private method parallel_unit_aux_trivial_conveyance =
+private method parallel_unit_left_aux_trivial_conveyance =
   (blast intro:
     acting_right
     opening_right
-    parallel_unit_aux.without_new_channel_rtl
+    parallel_unit_left_aux.without_new_channel_rtl
     basic_residual.rel_intros
   )
 
-lemma basic_parallel_unit: "\<zero> \<parallel> p \<sim>\<^sub>\<flat> p"
-proof (basic.bisimilarity_standard parallel_unit_aux)
+lemma basic_parallel_unit_left: "\<zero> \<parallel> p \<sim>\<^sub>\<flat> p"
+proof (basic.bisimilarity_standard parallel_unit_left_aux)
   case related
-  show ?case by (fact parallel_unit_aux.without_new_channel_ltr)
+  show ?case by (fact parallel_unit_left_aux.without_new_channel_ltr)
 next
   case sym
-  then show ?case by induction (simp_all add: parallel_unit_aux.intros)
+  then show ?case by induction (simp_all add: parallel_unit_left_aux.intros)
 next
   case (sim s t c)
   from this and \<open>s \<rightarrow>\<^sub>\<flat>c\<close> show ?case
-  proof (basic_sim_induction t with_new_channel: parallel_unit_aux.with_new_channel)
+  proof (basic_sim_induction t with_new_channel: parallel_unit_left_aux.with_new_channel)
     case sending
     from sending.prems show ?case
-      by cases parallel_unit_aux_trivial_conveyance
+      by cases parallel_unit_left_aux_trivial_conveyance
   next
     case receiving
     from receiving.prems show ?case
-      by cases parallel_unit_aux_trivial_conveyance
+      by cases parallel_unit_left_aux_trivial_conveyance
   next
     case communication
     from communication.prems show ?case
@@ -947,7 +947,7 @@ next
       case without_new_channel_ltr
       with communication.hyps show ?thesis
         by (simp add: no_basic_transitions_from_stop)
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   next
     case opening
     from opening.prems show ?case
@@ -956,7 +956,7 @@ next
       then show ?thesis
         using basic_transition.opening and basic_residual.rel_intros(2) and rel_funI
         by metis
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   next
     case acting_left
     from acting_left.prems show ?case
@@ -964,16 +964,16 @@ next
       case without_new_channel_ltr
       with acting_left.hyps show ?thesis
         by (simp add: no_basic_transitions_from_stop)
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   next
     case acting_right
     from acting_right.prems show ?case
     proof cases
       case without_new_channel_ltr
       with acting_right.hyps show ?thesis
-        using parallel_unit_aux.without_new_channel_ltr and basic_residual.rel_intros(1)
+        using parallel_unit_left_aux.without_new_channel_ltr and basic_residual.rel_intros(1)
         by auto
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   next
     case opening_left
     from opening_left.prems show ?case
@@ -981,7 +981,7 @@ next
       case without_new_channel_ltr
       with opening_left.hyps show ?thesis
         by (simp add: no_basic_transitions_from_stop)
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   next
     case opening_right
     from opening_right.prems show ?case
@@ -989,13 +989,16 @@ next
       case without_new_channel_ltr
       with opening_right.hyps show ?thesis
         using
-          parallel_unit_aux.without_new_channel_ltr and
+          parallel_unit_left_aux.without_new_channel_ltr and
           basic_residual.rel_intros(2) and
           rel_funI
         by smt
-    qed parallel_unit_aux_trivial_conveyance
+    qed parallel_unit_left_aux_trivial_conveyance
   qed
 qed
+
+lemma basic_parallel_unit_right: "p \<parallel> \<zero> \<sim>\<^sub>\<flat> p"
+  sorry
 
 end
 
@@ -1361,11 +1364,11 @@ qed
 lemma basic_parallel_commutativity: "p \<parallel> q \<sim>\<^sub>\<flat> q \<parallel> p"
 proof -
   have "p \<parallel> q \<sim>\<^sub>\<flat> (\<zero> \<parallel> p) \<parallel> q"
-    using basic_parallel_unit and basic_parallel_preservation_left by blast
+    using basic_parallel_unit_left and basic_parallel_preservation_left by blast
   also have "(\<zero> \<parallel> p) \<parallel> q \<sim>\<^sub>\<flat> (\<zero> \<parallel> q) \<parallel> p"
     by (fact basic_nested_parallel_commutativity)
   also have "(\<zero> \<parallel> q) \<parallel> p \<sim>\<^sub>\<flat> q \<parallel> p"
-    using basic_parallel_unit and basic_parallel_preservation_left by blast
+    using basic_parallel_unit_left and basic_parallel_preservation_left by blast
   finally show ?thesis .
 qed
 

--- a/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Basic_Weak_Transition_System.thy
@@ -70,7 +70,10 @@ lemma basic_weak_parallel_scope_extension_right: "p \<parallel> \<nu> a. Q a \<a
 lemma basic_weak_new_channel_scope_extension: "\<nu> b. \<nu> a. P a b \<approx>\<^sub>\<flat> \<nu> a. \<nu> b. P a b"
   sorry
 
-lemma basic_weak_parallel_unit: "\<zero> \<parallel> p \<approx>\<^sub>\<flat> p"
+lemma basic_weak_parallel_unit_left: "\<zero> \<parallel> p \<approx>\<^sub>\<flat> p"
+  sorry
+
+lemma basic_weak_parallel_unit_right: "p \<parallel> \<zero> \<approx>\<^sub>\<flat> p"
   sorry
 
 lemma basic_weak_parallel_commutativity: "p \<parallel> q \<approx>\<^sub>\<flat> q \<parallel> p"

--- a/Isabelle/Chi_Calculus/Proper_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Proper_Transition_System.thy
@@ -355,9 +355,12 @@ lemma proper_new_channel_scope_extension: "\<nu> b. \<nu> a. P a b \<sim>\<^sub>
   using basic_new_channel_scope_extension
   by (intro basic_bisimilarity_in_proper_bisimilarity_rule)
 
-lemma proper_parallel_unit: "\<zero> \<parallel> p \<sim>\<^sub>\<sharp> p"
-  using basic_parallel_unit
+lemma proper_parallel_unit_left: "\<zero> \<parallel> p \<sim>\<^sub>\<sharp> p"
+  using basic_parallel_unit_left
   by (intro basic_bisimilarity_in_proper_bisimilarity_rule)
+
+lemma proper_parallel_unit_right: "p \<parallel> \<zero> \<sim>\<^sub>\<sharp> p"
+  sorry
 
 lemma proper_parallel_commutativity: "p \<parallel> q \<sim>\<^sub>\<sharp> q \<parallel> p"
   using basic_parallel_commutativity
@@ -425,13 +428,13 @@ qed
 lemma proper_scope_redundancy: "p \<sim>\<^sub>\<sharp> \<nu> a. p"
 proof -
   have "p \<sim>\<^sub>\<sharp> \<zero> \<parallel> p"
-    by (rule proper.bisimilarity_symmetry_rule) (fact proper_parallel_unit)
+    by (rule proper.bisimilarity_symmetry_rule) (fact proper_parallel_unit_left)
   also have "\<zero> \<parallel> p \<sim>\<^sub>\<sharp> \<nu> a. \<zero> \<parallel> p"
     using proper_stop_scope_redundancy and proper_parallel_preservation_left by blast
   also have "\<nu> a. \<zero> \<parallel> p \<sim>\<^sub>\<sharp> \<nu> a. (\<zero> \<parallel> p)"
     by (fact proper_parallel_scope_extension_left)
   also have "\<nu> a. (\<zero> \<parallel> p) \<sim>\<^sub>\<sharp> \<nu> a. p"
-    using proper_parallel_unit and proper_new_channel_preservation by metis
+    using proper_parallel_unit_left and proper_new_channel_preservation by metis
   finally show ?thesis .
 qed
 

--- a/Isabelle/Chi_Calculus/Proper_Weak_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Proper_Weak_Transition_System.thy
@@ -78,7 +78,10 @@ lemma proper_weak_parallel_scope_extension_right: "p \<parallel> \<nu> a. Q a \<
 lemma proper_weak_new_channel_scope_extension: "\<nu> b. \<nu> a. P a b \<approx>\<^sub>\<sharp> \<nu> a. \<nu> b. P a b"
   sorry
 
-lemma proper_weak_parallel_unit: "\<zero> \<parallel> p \<approx>\<^sub>\<sharp> p"
+lemma proper_weak_parallel_unit_left: "\<zero> \<parallel> p \<approx>\<^sub>\<sharp> p"
+  sorry
+
+lemma proper_weak_parallel_unit_right: "p \<parallel> \<zero> \<approx>\<^sub>\<sharp> p"
   sorry
 
 lemma proper_weak_parallel_commutativity: "p \<parallel> q \<approx>\<^sub>\<sharp> q \<parallel> p"


### PR DESCRIPTION
So far, there were `parallel_unit` laws that worked only on the left side of parallel composition. We rename them to `parallel_unit_left` and add counterparts `parallel_unit_right`.