### PR TITLE
Update chapter name in `README.md`

### DIFF
--- a/Isabelle/README.md
+++ b/Isabelle/README.md
@@ -25,7 +25,7 @@ Building
 ========
 
 Running `make` builds the PDF documents for the different Isabelle
-libraries and places them in `$ISABELLE_BROWSER_INFO/Cardano`. You can
+libraries and places them in `$ISABELLE_BROWSER_INFO/Ouroboros`. You can
 find out the value of `$ISABELLE_BROWSER_INFO` by running the following
 command:
 


### PR DESCRIPTION
The change of the Isabelle chapter name from “Cardano” to “Ouroboros” made in 082c7e819562f390cde4b036c92231e91b2ac5d1 hadn’t been reflected in `README.md` so far. This branch corrects that.