### PR TITLE
Make `equivalence_simp` work flawlessly with process functions

### DIFF
--- a/Isabelle/Utilities/Equivalences.thy
+++ b/Isabelle/Utilities/Equivalences.thy
@@ -5,7 +5,7 @@ begin
 named_theorems equivalence_simp_goal_preparation and equivalence_simp
 
 method equivalence_simp = (
-  simp only: equivalence_simp_goal_preparation [THEN sym];
+  simp only: equivalence_simp_goal_preparation [THEN sym] id_def comp_def;
     simp only: equivalence_simp [transferred]
 )
 


### PR DESCRIPTION
This resolves #94.