### PR TITLE
Add space after `ν` in syntax definitions

### DIFF
--- a/Isabelle/Chi_Calculus/Core_Bisimilarities.thy
+++ b/Isabelle/Chi_Calculus/Core_Bisimilarities.thy
@@ -1085,7 +1085,7 @@ definition tagged_new_channel :: "[nat, chan \<Rightarrow> process] \<Rightarrow
 
 syntax
   "_tagged_new_channel" :: "[bool list, pttrn, process] \<Rightarrow> process"
-  ("(3\<langle>_\<rangle> \<nu>_./ _)" [0, 0, 100] 100)
+  ("(3\<langle>_\<rangle> \<nu> _./ _)" [0, 0, 100] 100)
 translations
   "\<langle>t\<rangle> \<nu> a. p" \<rightleftharpoons> "CONST tagged_new_channel t (\<lambda>a. p)"
 

--- a/Isabelle/Chi_Calculus/Processes.thy
+++ b/Isabelle/Chi_Calculus/Processes.thy
@@ -14,7 +14,7 @@ codatatype process =
   Send \<open>chan\<close> \<open>val\<close> (infix "\<triangleleft>" 100) |
   Receive \<open>chan\<close> \<open>val \<Rightarrow> process\<close> |
   Parallel \<open>process\<close> \<open>process\<close> (infixr "\<parallel>" 65) |
-  NewChannel \<open>chan \<Rightarrow> process\<close> (binder "\<nu>" 100)
+  NewChannel \<open>chan \<Rightarrow> process\<close> (binder "\<nu> " 100)
 
 text \<open>
   The notation for \<^const>\<open>Receive\<close> cannot be declared with @{theory_text \<open>binder\<close>}, for the

--- a/Isabelle/Chi_Calculus/Proper_Transition_System.thy
+++ b/Isabelle/Chi_Calculus/Proper_Transition_System.thy
@@ -32,7 +32,7 @@ text \<open>
 
 datatype 't output_rest =
   WithoutOpening \<open>val\<close> \<open>'t\<close> ("_\<rparr> _" [52, 51] 51) |
-  WithOpening \<open>chan \<Rightarrow> 't output_rest\<close> (binder "\<nu>" 51)
+  WithOpening \<open>chan \<Rightarrow> 't output_rest\<close> (binder "\<nu> " 51)
 
 text \<open>
   Note that the definition of \<open>output_rest\<close> is actually more permissive than the verbal definition


### PR DESCRIPTION
This resolves #166.